### PR TITLE
Expose Ok.value and Err.error (closes #3)

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -12,11 +12,7 @@ export const err = <T, E>(err: E): Err<T, E> => new Err(err)
 
 
 export class Ok<T, E> {
-  private value: T
-
-  constructor(value: T) {
-    this.value = value
-  }
+  constructor(readonly value: T) { }
 
   isOk(): this is Ok<T, E> {
     return true
@@ -64,11 +60,7 @@ export class Ok<T, E> {
 }
 
 export class Err<T, E> {
-  private error: E
-
-  constructor(error: E) {
-    this.error = error
-  }
+  constructor(readonly error: E) { }
 
   isOk(): this is Ok<T, E> {
     return false

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { ok, err, Ok, Err } from '../src'
+import { ok, err, Ok, Err, Result } from '../src'
 
 describe('Result.Ok', () => {
   it('Creates an Ok value', () => {
@@ -129,6 +129,17 @@ describe('Result.Ok', () => {
     const okVal = ok(12)
 
     expect(okVal._unsafeUnwrap()).toBe(12)
+  })
+
+  it('Can read the value after narrowing', () => {
+    const fallible: () => Result<string, number> = () => ok('safe to read');
+    const val = fallible();
+
+    // After this check we val is narrowed to Ok<string, number>. Without this
+    // line TypeScript will not allow accessing val.value.
+    if (val.isErr()) return;
+
+    expect(val.value).toBe('safe to read');
   })
 })
 


### PR DESCRIPTION
Implements the idea from #3. Does not sacrifice type safety.