### PR TITLE
📝 README update match method

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,58 @@ const notNested = nested.andThen(innerResult => innerResult)
 
 ---
 
+### `Result.match` (method)
+
+Given 2 functions (one for the `Ok` variant and one for the `Err` variant) execute the function that matches the `Result` variant.
+
+Match callbacks do not necessitate to return a `Result`, however you can return a `Result` if you want to.
+
+**Signature:**
+```typescript
+match<A>(
+  okFn: (t:  T) =>  A,
+  errFn: (e:  E) =>  A
+): A => { ... }
+```
+
+
+`match` is like chaining `map` and `mapErr`, with the distinction that with `match` both functions must have the same return type.
+
+
+**Example:**
+
+```typescript
+const result = computationThatMightFail()
+
+const successCallback = (someNumber: number) => {
+  console.log('> number is: ', someNumber)
+}
+
+const failureCallback = (someFailureValue: string) => {
+  console.log('> boooooo')
+}
+
+// method chaining api
+// note that you DONT have to append mapErr
+// after map which means that you are not required to do
+// error handling
+result
+  .map(successCallback)
+  .mapErr(failureCallback)
+
+
+// match api
+// works exactly the same as above,
+// except, now you HAVE to do error handling :)
+myval.match(
+  successCallback,
+  failureCallback
+)
+```
+
+
+---
+
 ### `Result.asyncMap` (method)
 
 Similar to `map` except for two things:
@@ -318,38 +370,6 @@ const result = err(12)
 const twelve = result._unsafeUnwrapErr()
 ```
 
-
----
-
-### `Result.match` (method)
-
-Given 2 functions (one for the `Ok` variant and one for the `Err` variant) execute the function that matches the `Result` variant.
-
-Both functions will unwrap the `Result` object and must have the same return type.
-
-`match` is sort of like combining `_unsafeUnwrap` and `_unsafeUnwrapErr`.
-
-
-
-**Signature:**
-```typescript
-match<A>(
-  okFn: (t:  T) =>  A,
-  errFn: (e:  E) =>  A
-): A => { ... }
-```
-
-
-**Example:**
-
-```typescript
-const result = computationThatMightFail()
-
-const matched = result.match(
-  (innerOkValue) => { return 'Yey' },
-  (innerErrValue) => { return 'OhNooo' }
-)
-```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -254,37 +254,6 @@ const notNested = nested.andThen(innerResult => innerResult)
 
 ---
 
-### `Result.match` (method)
-
-Given 2 functions (one for the `Ok` variant and one for the `Err` variant) execute the function that matches the `Result` variant.
-
-`match` is sort of like combining `map` and `mapErr`.
-
-
-
-**Signature:**
-```typescript
-match<U, A>(
-  okFn: (t:  T) =>  U,
-  errFn: (e:  E) =>  A
-):  U | A => { ... }
-```
-
-
-**Example:**
-
-```typescript
-const result = computationThatMightFail()
-
-const matched = result.match(
-  (innerOkValue) => { return 'Yey' },
-  (innerErrValue) => { return 'OhNooo' }
-)
-```
-
-
----
-
 ### `Result.asyncMap` (method)
 
 Similar to `map` except for two things:
@@ -347,6 +316,39 @@ import { err } from 'neverthrow'
 const result = err(12)
 
 const twelve = result._unsafeUnwrapErr()
+```
+
+
+---
+
+### `Result.match` (method)
+
+Given 2 functions (one for the `Ok` variant and one for the `Err` variant) execute the function that matches the `Result` variant.
+
+Both functions will unwrap the `Result` object and must have the same return type.
+
+`match` is sort of like combining `_unsafeUnwrap` and `_unsafeUnwrapErr`.
+
+
+
+**Signature:**
+```typescript
+match<A>(
+  okFn: (t:  T) =>  A,
+  errFn: (e:  E) =>  A
+): A => { ... }
+```
+
+
+**Example:**
+
+```typescript
+const result = computationThatMightFail()
+
+const matched = result.match(
+  (innerOkValue) => { return 'Yey' },
+  (innerErrValue) => { return 'OhNooo' }
+)
 ```
 
 ---


### PR DESCRIPTION
There was some deprecated doc for the match method (mentioned in this issue : https://github.com/gDelgado14/neverthrow/issues/11).

Also it was not specified that the return type is not a Result, meaning the match method is more a combination of _unsafeUnwrap and _unsafeUnwrapErr, rather than map and mapErr.